### PR TITLE
1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.0.0] - 2022-02-02
+
+### [1.0.0] Changed
+
+- Changed the parameters default values of `isWrapped()` instance method to private `#opening` and `#closing`. [44bd1f5]
+- Changed the default values of the `opening` and `closing` parameters in the static `unwrap()` method by removing them. [d8d0f4b]
+- Changed the default value for the generic type variable `Text` of the `isWrapper()` static method to `string`. [d8d0f4b]
+- Changed the `toStringTag` name from the `wrapper` to `Wrapper`. [d8d0f4b]
+- Changed the `toStringTag` name from the `wrap` to `Wrap`. [4049e2e]
+
+[44bd1f5]: https://github.com/angular-package/wrapper/commit/44bd1f54d82700440012caa5414a02ff8687ffb2
+[d8d0f4b]: https://github.com/angular-package/wrapper/commit/d8d0f4bb029395a2de180fc38246a9ea81d7eb58
+[4049e2e]: https://github.com/angular-package/wrapper/commit/4049e2ea09104ac155bf7b385789b40ca7b923c1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular-package/wrapper",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Wrap the text with the opening and closing chars.",
   "author": "Angular Package <contact@angular-package.dev> (https://angular-package.dev)",
   "homepage": "https://wrapper.angular-package.dev/",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Wrap the text with the opening and closing chars.",
   "author": "Angular Package <contact@angular-package.dev> (https://angular-package.dev)",
-  "homepage": "https://github.com/angular-package/wrapper#readme",
+  "homepage": "https://wrapper.angular-package.dev/",
   "dependencies": {
     "tslib": "^2.3.0"
   },

--- a/src/lib/wrap.class.ts
+++ b/src/lib/wrap.class.ts
@@ -43,7 +43,7 @@ export class Wrap<
    * @angularpackage
    */
   public get [Symbol.toStringTag](): string {
-    return 'wrap';
+    return 'Wrap';
   }
   //#endregion instance public accessors.
 
@@ -174,8 +174,8 @@ export class Wrap<
   }
 
   /**
-   * Checks whether the primitive value of a specified object has the closing chars or given closing chars. If given closing chars in the
-   * constructor are the empty `string`, the method returns `false`.
+   * Checks whether the primitive value of a specified object has the closing chars or given `closing` chars. If given `closing` chars in
+   * the constructor are the empty `string`, the method returns `false`.
    * @param closing Optional closing chars of a `string` type to check whether the primitive value contains them at the **end**.
    * @returns The return value is a `boolean` indicating whether the primitive value has the closing chars or given closing chars.
    * @angularpackage
@@ -188,8 +188,8 @@ export class Wrap<
   }
 
   /**
-   * Checks whether the primitive value of a specified object has the opening chars or given opening chars. If given opening chars in the
-   * constructor are the empty `string`, the method returns `false`.
+   * Checks whether the primitive value of a specified object has the opening chars or given `opening` chars. If given `opening` chars in
+   * the constructor are the empty `string`, the method returns `false`.
    * @param opening Optional opening chars of a `string` type to check if the primitive value contains them at the **beginning**.
    * @returns The return value is a `boolean` indicating whether the primitive value has the opening chars or given `opening` chars.
    * @angularpackage
@@ -217,8 +217,8 @@ export class Wrap<
 
   /**
    * The method checks whether the primitive value of the specified `object` is wrapped by the opening and closing chars of an instance or
-   * given `opening` and `closing` chars. If given opening or closing chars in the constructor are the empty `string`, the method returns
-   * `false`.
+   * given `opening` and `closing` chars. If given `opening` or `closing` chars in the constructor are the empty `string`, the method
+   * returns `false`.
    * @param opening Optional opening chars of a `string` type to check if the primitive value contains them at the beginning. The default
    * value is picked from the private `#opening` property of an instance.
    * @param closing Optional closing chars of a `string` type to check if the primitive value contains them at the end. The default value is

--- a/src/lib/wrap.class.ts
+++ b/src/lib/wrap.class.ts
@@ -1,6 +1,7 @@
 /**
- * The `Wrap` object represents the immutable text wrapped by the opening and closing chars. It is designed to preserve the names of the
- * opening, text and closing.
+ * The `Wrap` object is based on the `String` object and represents the immutable primitive value of the text wrapped by the opening and
+ * closing chars. It is designed to preserve the type names of the supplied opening, text, and closing chars by using the generic type
+ * variables.
  */
 export class Wrap<
   Opening extends string = string,
@@ -53,15 +54,15 @@ export class Wrap<
   #closing: Closing;
 
   /**
-   * Private property of text of a generic type variable `Text`.
-   */
-  #text: Text;
-
-  /**
    * Private property of the opening chars of a generic type variable `Opening`.
    */
   #opening: Opening;
-  //#endregion instance private properties.
+
+  /**
+   * Private property of text of a generic type variable `Text`.
+   */
+   #text: Text;
+   //#endregion instance private properties.
 
   //#region static public methods.
   /**
@@ -173,8 +174,8 @@ export class Wrap<
   /**
    * Checks whether the primitive value of a specified object has the closing chars or given closing chars. An empty `string` indicates
    * `undefined`.
-   * @param closing Optional closing chars of a `string` type to check whether the primitive value contains them at the end.
-   * @returns The return value is a `boolean` indicating whether the primitive value has the closing chars.
+   * @param closing Optional closing chars of a `string` type to check whether the primitive value contains them at the **end**.
+   * @returns The return value is a `boolean` indicating whether the primitive value has the closing chars or given closing chars.
    * @angularpackage
    */
   public hasClosing(closing?: string): boolean {
@@ -187,8 +188,8 @@ export class Wrap<
   /**
    * Checks whether the primitive value of a specified object has the opening chars or given opening chars. An empty `string` indicates
    * `undefined`.
-   * @param opening Optional opening chars of a `string` type to check if the primitive value contains them at the beginning.
-   * @returns The return value is a `boolean` indicating whether the primitive value has the opening chars.
+   * @param opening Optional opening chars of a `string` type to check if the primitive value contains them at the **beginning**.
+   * @returns The return value is a `boolean` indicating whether the primitive value has the opening chars or given `opening` chars.
    * @angularpackage
    */
   public hasOpening(opening?: string): boolean {
@@ -202,7 +203,7 @@ export class Wrap<
    * The method checks whether the text of a specified `Wrap` object is defined, which means it's a `string` of at least one char and
    * optionally equal to the given `text`.
    * @param text Optional text of `string` type to check whether it's equal to the text of the `Wrap` object.
-   * @returns The return value is a `boolean` indicating whether the text is defined and equal to the optionally given text.
+   * @returns The return value is a `boolean` indicating whether the text is defined and optionally equal to the given text.
    * @angularpackage
    */
   public hasText(text?: string): boolean {
@@ -214,10 +215,11 @@ export class Wrap<
 
   /**
    * The method checks whether the primitive value of the specified object is wrapped by the opening and closing chars of an instance or
-   * given opening and closing chars.
-   * @param opening Optional opening chars of a `string` type to check if the text contains them at the beginning.
-   * @param closing Optional closing chars of a `string` type to check if the text contains them at the end.
-   * @returns The return value is a `boolean` indicating whether the object has both opening and closing chars.
+   * given `opening` and `closing` chars.
+   * @param opening Optional opening chars of a `string` type to check if the primitive value contains them at the beginning.
+   * @param closing Optional closing chars of a `string` type to check if the primitive value contains them at the end.
+   * @returns The return value is a `boolean` indicating whether the object has both opening and closing chars or given `opening` and
+   * `closing` chars.
    * @angularpackage
    */
   public isWrapped(

--- a/src/lib/wrap.class.ts
+++ b/src/lib/wrap.class.ts
@@ -130,8 +130,10 @@ export class Wrap<
   //#region constructor.
   /**
    * Creates a new `Wrap` instance of the opening and closing chars and optional text to wrap.
-   * @param opening Opening characters of the generic type variable `Opening` placed before the given `text`.
-   * @param closing Closing characters of the generic type variable `Closing` placed after the given `text`.
+   * @param opening Opening characters of the generic type variable `Opening` placed before the given `text`. An empty `string` indicates
+   * that for the `hasOpening()` and `isWrapped()` methods, the opening chars are `undefined`, returning `false`.
+   * @param closing Closing characters of the generic type variable `Closing` placed after the given `text`. An empty `string` indicates
+   * that for the `hasClosing()` and `isWrapped()` methods, the closing chars are `undefined`, returning `false`.
    * @param text An optional text placed between the given `opening` and `closing` chars on the template `${Opening}${Text}${Closing}`.
    * @angularpackage
    */
@@ -172,8 +174,8 @@ export class Wrap<
   }
 
   /**
-   * Checks whether the primitive value of a specified object has the closing chars or given closing chars. An empty `string` indicates
-   * `undefined`.
+   * Checks whether the primitive value of a specified object has the closing chars or given closing chars. If given closing chars in the
+   * constructor are the empty `string`, the method returns `false`.
    * @param closing Optional closing chars of a `string` type to check whether the primitive value contains them at the **end**.
    * @returns The return value is a `boolean` indicating whether the primitive value has the closing chars or given closing chars.
    * @angularpackage
@@ -186,8 +188,8 @@ export class Wrap<
   }
 
   /**
-   * Checks whether the primitive value of a specified object has the opening chars or given opening chars. An empty `string` indicates
-   * `undefined`.
+   * Checks whether the primitive value of a specified object has the opening chars or given opening chars. If given opening chars in the
+   * constructor are the empty `string`, the method returns `false`.
    * @param opening Optional opening chars of a `string` type to check if the primitive value contains them at the **beginning**.
    * @returns The return value is a `boolean` indicating whether the primitive value has the opening chars or given `opening` chars.
    * @angularpackage
@@ -214,17 +216,20 @@ export class Wrap<
   }
 
   /**
-   * The method checks whether the primitive value of the specified object is wrapped by the opening and closing chars of an instance or
-   * given `opening` and `closing` chars.
-   * @param opening Optional opening chars of a `string` type to check if the primitive value contains them at the beginning.
-   * @param closing Optional closing chars of a `string` type to check if the primitive value contains them at the end.
+   * The method checks whether the primitive value of the specified `object` is wrapped by the opening and closing chars of an instance or
+   * given `opening` and `closing` chars. If given opening or closing chars in the constructor are the empty `string`, the method returns
+   * `false`.
+   * @param opening Optional opening chars of a `string` type to check if the primitive value contains them at the beginning. The default
+   * value is picked from the private `#opening` property of an instance.
+   * @param closing Optional closing chars of a `string` type to check if the primitive value contains them at the end. The default value is
+   * picked from the private `#closing` property of an instance.
    * @returns The return value is a `boolean` indicating whether the object has both opening and closing chars or given `opening` and
    * `closing` chars.
    * @angularpackage
    */
   public isWrapped(
-    opening: string = this.opening,
-    closing: string = this.closing
+    opening: string = this.#opening,
+    closing: string = this.#closing
   ): boolean {
     return this.hasOpening(opening) && this.hasClosing(closing);
   }

--- a/src/lib/wrapper.class.ts
+++ b/src/lib/wrapper.class.ts
@@ -17,7 +17,7 @@ export class Wrapper<
    * `typeOf()` function of `@angular-package/type`.
    */
   public get [Symbol.toStringTag](): string {
-    return 'wrapper';
+    return 'Wrapper';
   }
   //#endregion instance accessors.
 
@@ -43,7 +43,7 @@ export class Wrapper<
   }
 
   /**
-   * The method checks if the value of any type is an instance of the `Wrapper` of any, or the given opening, closing chars, and text.
+   * The method checks if the value of any type is an instance of the `Wrapper` of any, or the given `opening`, `closing` chars, and `text`.
    * @param value The value of any type to test against the `Wrapper` instance.
    * @param opening Optional opening chars of generic type variable `Opening` to check if the given `value` contains.
    * @param closing Optional closing chars of generic type variable `Closing` to check if the given `value` contains.
@@ -55,7 +55,7 @@ export class Wrapper<
   public static isWrapper<
     Opening extends string,
     Closing extends string,
-    Text extends string = ''
+    Text extends string = string
   >(
     value: any,
     opening?: Opening,
@@ -70,11 +70,12 @@ export class Wrapper<
   }
 
   /**
-   * Replaces the closing chars in a given `text` with a given replacement value at the end of the text.
+   * Replaces given `closing` chars with a given replacement value at the end of the given `text`.
    * @param text The text of `string` type in which given `closing` characters are replaced by a given replacement value.
    * @param closing The closing chars of the `string` to replace by a given replacement value at the end of the given `text`.
-   * @param replaceValue Replacement value for the given `closing` characters in the given `text`.
-   * @returns The return value is the text of `string` type with a replaced closing chars by a given replacement value.
+   * @param replaceValue The replacement value of a string type for the given `closing` characters in the given `text`.
+   * @returns The return value is the given `text` of `string` type with a replaced `closing` chars by a given replacement value or the
+   * specified `text` unchanged if it does not contain the given `closing` chars.
    * @angularpackage
    */
   public static replaceClosing(
@@ -88,11 +89,12 @@ export class Wrapper<
   }
 
   /**
-   * Replaces the opening chars in a given `text` with a given replacement value at the beginning of the text.
+   * Replaces given `opening` chars with a given replacement value at the beginning of the given `text`.
    * @param text The text of `string` type in which the given `opening` chars are replaced by a given replacement value.
    * @param opening The opening chars of the `string` to replace by a given replacement value at the beginning of the given `text`.
-   * @param replaceValue Replacement value for the `opening` characters in the given `text`.
-   * @returns The return value is the text of `string` type with a replaced opening chars by a given replacement value.
+   * @param replaceValue The replacement value of a string type for the given `opening` characters in the given `text`.
+   * @returns The return value is the given `text` of `string` type with a replaced `opening` chars by a given replacement value or the
+   * specified `text` unchanged if it does not contain the given `opening` chars.
    * @angularpackage
    */
   public static replaceOpening(
@@ -106,14 +108,15 @@ export class Wrapper<
   }
 
   /**
-   * The method returns the text without the given `opening` and `closing` chars.
+   * The method returns the given `text` without the given `opening` and `closing` chars.
    * @param text The text of the `string` from which given opening and closing chars are removed.
    * @param opening The opening chars of the `string` to be removed in the given `text`.
    * @param closing The closing chars of the `string` to be removed in the given `text`.
-   * @returns The return value is the text of string type without the given opening and closing chars.
+   * @returns The return value is the given `text` of `string` type without the given `opening` and `closing` chars or unchanged `text` if
+   * it does not contain the given `opening` and `closing` chars.
    * @angularpackage
    */
-  public static unwrap(text: string, opening = '', closing = ''): string {
+  public static unwrap(text: string, opening: string, closing: string): string {
     return (
       (text = this.replaceClosing(text, closing, '')),
       (text = this.replaceOpening(text, opening, '')),
@@ -162,7 +165,7 @@ export class Wrapper<
    * The replacement succeeds if the closing characters exist at the end of the text.
    * @param text The text of `string` type in which the closing chars are replaced by given replacement value.
    * @param replaceValue The value of `string` type as a replacement for the closing chars at the end of the given `text`.
-   * @returns The return value is the text of `string` type with replaced closing chars by given replacement value.
+   * @returns The return value is the given `text` of `string` type with replaced closing chars by given replacement value.
    * @angularpackage
    */
   public replaceClosingIn(text: string, replaceValue: string): string {
@@ -174,7 +177,7 @@ export class Wrapper<
    * The replacement succeeds if the opening characters exist at the beginning of the text.
    * @param text The text of `string` type in which the opening chars are replaced by given replacement value.
    * @param replaceValue The value of `string` type as a replacement for the opening chars at the beginning of the given `text`.
-   * @returns The return value is the text of `string` type with replaced opening chars by given replacement value.
+   * @returns The return value is the given `text` of `string` type with replaced opening chars by given replacement value.
    * @angularpackage
    */
   public replaceOpeningIn(text: string, replaceValue: string): string {
@@ -183,7 +186,7 @@ export class Wrapper<
 
   /**
    * Returns given `text` without the opening and closing chars of the `Wrapper` object.
-   * @param text The text of a `string` type to unwrap with the opening and closing chars of the `Wrapper` object.
+   * @param text The text of a `string` type to unwrap from the opening and closing chars of the `Wrapper` object.
    * @returns The return value is the text of `string` type unwrapped from the opening and closing chars of the `Wrapper` object.
    * @angularpackage
    */
@@ -210,7 +213,7 @@ export class Wrapper<
    * Replaces the opening chars of the `Wrapper` object in the text of the `Wrapper` object with the given `opening` chars. The replacement
    * succeeds if the opening characters exist at the beginning of the text.
    * @param opening The opening chars of `string` to replace in the text(part of the primitive value).
-   * @returns The return value is the text of string type with replaced opening chars.
+   * @returns The return value is the text of `string` type with replaced opening chars.
    * @angularpackage
    */
   public textReplaceOpening(opening: string): string {
@@ -276,8 +279,8 @@ export class Wrapper<
   }
 
   /**
-   * The method returns the primitive value of a specified `Wrapper` object with text unwrapped from its opening and closing chars or given
-   * `opening` and `closing` chars.
+   * The method returns the primitive value of a specified `Wrapper` object with text unwrapped from the opening and closing chars of the
+   * `Wrapper` instance or given `opening` and `closing` chars.
    * @param opening Optional opening chars of `string` type to remove from the beginning of the text of the `Wrapper` instance. By default,
    * its value is equal to the opening chars of the `Wrapper` instance.
    * @param closing Optional closing chars of `string` type to remove from the end of the text of the `Wrapper` instance. By default, its
@@ -299,10 +302,11 @@ export class Wrapper<
    * The method wraps the primitive value of a specified `Wrapper` object by its opening and closing chars or given `opening` and `closing`
    * chars.
    * @param opening Optional opening chars of a generic type variable `CustomOpening` to wrap the primitive value of the `Wrapper` instance.
-   * By default, its value is equal to the closing chars of the `Wrapper` instance.
+   * By default, its value is equal to the opening chars of the `Wrapper` instance.
    * @param closing Optional closing chars of a generic type variable `CustomClosing` to wrap the primitive value of the `Wrapper` instance.
    * By default, its value is equal to the closing chars of the `Wrapper` instance.
-   * @returns The return value is a primitive value wrapped by the given opening and closing chars or from the `Wrapper` instance.
+   * @returns The return value is a primitive value wrapped by the opening and closing chars of the `Wrapper` instance or the given
+   * `opening` and `closing` chars.
    * @angularpackage
    */
   public wrap<
@@ -316,9 +320,10 @@ export class Wrapper<
   }
 
   /**
-   * Wraps given text with the wrap, the opening, and closing chars of the `Wrapper` object.
+   * The method wraps the given `text` with the wrap, the `opening`, and `closing` chars of the `Wrapper` object.
    * @param text The text of generic type variable `CustomText` to wrap by the opening and closing chars of the `Wrapper` instance.
-   * @returns The return value is the text wrapped by the opening and closing chars of the `Wrapper` object of the generic type `Wrapped`.
+   * @returns The return value is the given `text` wrapped by the opening and closing chars of the `Wrapper` object of the generic type
+   * `Wrapped`.
    * @angularpackage
    */
   public wrapOn<CustomText extends string = ''>(

--- a/src/test/wrap.spec.ts
+++ b/src/test/wrap.spec.ts
@@ -1,5 +1,5 @@
 import { typeOf } from '@angular-package/type';
-import { Testing, TestingToBeMatchers } from '@angular-package/testing';
+import { Testing, TestingToBeMatchers, TESTING_ARRAY_BIGINT } from '@angular-package/testing';
 import { Wrap } from '../lib/wrap.class';
 
 const testing = new Testing(true, true);
@@ -14,6 +14,9 @@ testing.describe(`Wrap`, () => {
   const replaceText = 'span';
   const text = `quote`;
   const wrap = new Wrap(opening, closing, text);
+  const wrapNull = new Wrap(null as any, null as any);
+  const wrapUndefined = new Wrap(undefined as any, undefined as any, undefined as any);
+  const wrapArrayBigInt = new Wrap(TESTING_ARRAY_BIGINT as any, TESTING_ARRAY_BIGINT as any);
 
   testing
 
@@ -22,26 +25,37 @@ testing.describe(`Wrap`, () => {
 
         .it(`Wrap.prototype.closing`, () => {
           expect(wrap.closing).toEqual(closing);
+          expect(wrapNull.closing).toEqual('null');
+          expect(wrapUndefined.closing).toEqual('undefined');
           toBe.stringIncludes(wrap.closing, [closing]);
+          expect(wrapArrayBigInt.closing).toEqual('9007199254740991,9007199254740991');
         })
 
         .it(`Wrap.prototype.opening`, () => {
           expect(wrap.opening).toEqual(opening);
+          expect(wrapNull.opening).toEqual('null');
+          expect(wrapUndefined.opening).toEqual('undefined');
           toBe.stringIncludes(wrap.valueOf(), [opening]);
+          expect(wrapArrayBigInt.opening).toEqual('9007199254740991,9007199254740991');
         })
 
         .it(`Wrap.prototype.text`, () => {
           expect(wrap.text).toEqual(text);
+          expect(wrapNull.text).toEqual('');
+          expect(wrapUndefined.text).toEqual('');
           toBe.stringIncludes(wrap.valueOf(), [text]);
         })
 
-        .it(`Wrap.prototype.value`, () => {
+        .it(`Wrap.prototype.valueOf()`, () => {
           expect(wrap.valueOf()).toEqual(`${opening}${text}${closing}`);
+          expect(wrapNull.valueOf()).toEqual('nullnull');
+          expect(wrapUndefined.valueOf()).toEqual('undefinedundefined');
           toBe.stringIncludes(wrap.valueOf(), [opening, text, closing]);
         })
 
         .it(`[Symbol.toStringTag]`, () => {
           expect(typeOf(wrap)).toEqual('wrap');
+          expect(Object.prototype.toString.call(wrap)).toEqual('[object Wrap]');
         });
     })
 
@@ -56,6 +70,21 @@ testing.describe(`Wrap`, () => {
           expect(Wrap.isWrap(wrap, opening, undefined, undefined)).toEqual(true);
           expect(Wrap.isWrap(wrap, opening, closing, undefined)).toEqual(true);
         })
+
+        .it(`Wrap.hasClosing()`, () => {
+          expect(Wrap.hasClosing(`${opening}${text}${closing}`, closing)).toBeTrue();
+          expect(Wrap.hasClosing(`${opening}${text}${closing}`, opening)).toBeFalse();
+        })
+
+        .it(`Wrap.hasOpening()`, () => {
+          expect(Wrap.hasOpening(`${opening}${text}${closing}`, opening)).toBeTrue();
+          expect(Wrap.hasOpening(`${opening}${text}${closing}`, closing)).toBeFalse();
+        });
+
+    })
+
+    .describe(`methods`, () => {
+      testing
 
         .it(`Wrap.prototype.getClosing()`, () => {
           expect(wrap.getClosing()).toEqual(closing);
@@ -139,6 +168,8 @@ testing.describe(`Wrap`, () => {
           expect(new Wrap('<', '>').isWrapped()).toBeTrue();
           expect(new Wrap('<', '>').isWrapped('<')).toBeTrue();
           expect(new Wrap('<', '>').isWrapped(undefined, '>')).toBeTrue();
+          expect(new Wrap('<', '>').isWrapped('', '>')).toBeFalse();
+          expect(new Wrap('<', '>').isWrapped('<', '')).toBeFalse();
         })
 
         .it(`Wrap.prototype.replaceClosing()`, () => {

--- a/src/test/wrapper.spec.ts
+++ b/src/test/wrapper.spec.ts
@@ -55,8 +55,8 @@ testing.describe(`Wrapper`, () => {
         })
         .it(`Wrapper.unwrap()`, () => {
           expect(Wrapper.unwrap(`${opening}${text}${closing}`, opening, closing)).toEqual(text);
-          expect(Wrapper.unwrap(`${opening}${text}${closing}`, undefined, closing)).toEqual(`${opening}${text}${''}`);
-          expect(Wrapper.unwrap(`${opening}${text}${closing}`, opening, undefined)).toEqual(`${''}${text}${closing}`);
+          expect(Wrapper.unwrap(`${opening}${text}${closing}`, undefined as any, closing)).toEqual(`${opening}${text}${''}`);
+          expect(Wrapper.unwrap(`${opening}${text}${closing}`, opening, undefined as any)).toEqual(`${''}${text}${closing}`);
         })
 
         ;
@@ -66,6 +66,7 @@ testing.describe(`Wrapper`, () => {
       testing
       .it(`[Symbol.toStringTag]`, () => {
         expect(typeOf(wrapper)).toEqual('wrapper');
+        expect(Object.prototype.toString.call(wrapper)).toEqual('[object Wrapper]');
       });
     })
 


### PR DESCRIPTION
## [1.0.0] - 2022-02-02

### [1.0.0] Changed

- Changed the parameters default values of `isWrapped()` instance method to private `#opening` and `#closing`. [44bd1f5]
- Changed the default values of the `opening` and `closing` parameters in the static `unwrap()` method by removing them. [d8d0f4b]
- Changed the default value for the generic type variable `Text` of the `isWrapper()` static method to `string`. [d8d0f4b]
- Changed the `toStringTag` name from the `wrapper` to `Wrapper`. [d8d0f4b]
- Changed the `toStringTag` name from the `wrap` to `Wrap`. [4049e2e]

[44bd1f5]: https://github.com/angular-package/wrapper/commit/44bd1f54d82700440012caa5414a02ff8687ffb2
[d8d0f4b]: https://github.com/angular-package/wrapper/commit/d8d0f4bb029395a2de180fc38246a9ea81d7eb58
[4049e2e]: https://github.com/angular-package/wrapper/commit/4049e2ea09104ac155bf7b385789b40ca7b923c1
